### PR TITLE
Draft: Backwards compatible transport types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,9 @@
         "@sentry/node": "^7.5.0",
         "@sentry/tracing": "^7.5.0",
         "@sentry/types": "^7.5.0",
+        "@sentry4/types": "npm:@sentry/types@^4.5.3",
+        "@sentry5/types": "npm:@sentry/types@^5.30.0",
+        "@sentry6/types": "npm:@sentry/types@^6.19.7",
         "@types/body-parser": "^1.19.2",
         "@types/express": "^4.17.14",
         "@types/jest": "^27.0.0",
@@ -36,6 +39,7 @@
         "nock": "^10.0.6",
         "node-fetch": "^2.6.7",
         "prettier": "^1.19.1",
+        "rimraf": "^3.0.2",
         "standard-version": "^9.3.1",
         "ts-jest": "^27.0.0",
         "typescript": "^4.8.4",
@@ -2763,6 +2767,36 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@sentry4/types": {
+      "name": "@sentry/types",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-4.5.3.tgz",
+      "integrity": "sha512-7ll1PAFNjrBNX9rzy3P2qAQrpQwHaDO3uKj735qsnGw34OtAS8Xr8WYrjI14f9fMPa/XIeWvMPb4GMic28V/ag==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry5/types": {
+      "name": "@sentry/types",
+      "version": "5.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.30.0.tgz",
+      "integrity": "sha512-R8xOqlSTZ+htqrfteCWU5Nk0CDN5ApUTvrlvBuiH1DyP6czDZ4ktbZB0hAgBlVcK0U+qpD3ag3Tqqpa5Q67rPw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry6/types": {
+      "name": "@sentry/types",
+      "version": "6.19.7",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.19.7.tgz",
+      "integrity": "sha512-jH84pDYE+hHIbVnab3Hr+ZXr1v8QABfhx39KknxqKWr2l0oEItzepV0URvbEhB446lk/S/59230dlUUIBGsXbg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@sindresorhus/is": {
@@ -16125,6 +16159,24 @@
         "@sentry/types": "7.5.0",
         "tslib": "^1.9.3"
       }
+    },
+    "@sentry4/types": {
+      "version": "npm:@sentry/types@4.5.3",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-4.5.3.tgz",
+      "integrity": "sha512-7ll1PAFNjrBNX9rzy3P2qAQrpQwHaDO3uKj735qsnGw34OtAS8Xr8WYrjI14f9fMPa/XIeWvMPb4GMic28V/ag==",
+      "dev": true
+    },
+    "@sentry5/types": {
+      "version": "npm:@sentry/types@5.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.30.0.tgz",
+      "integrity": "sha512-R8xOqlSTZ+htqrfteCWU5Nk0CDN5ApUTvrlvBuiH1DyP6czDZ4ktbZB0hAgBlVcK0U+qpD3ag3Tqqpa5Q67rPw==",
+      "dev": true
+    },
+    "@sentry6/types": {
+      "version": "npm:@sentry/types@6.19.7",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.19.7.tgz",
+      "integrity": "sha512-jH84pDYE+hHIbVnab3Hr+ZXr1v8QABfhx39KknxqKWr2l0oEItzepV0URvbEhB446lk/S/59230dlUUIBGsXbg==",
+      "dev": true
     },
     "@sindresorhus/is": {
       "version": "0.14.0",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,10 @@
     "dist"
   ],
   "scripts": {
+    "clean": "rimraf dist/**",
     "build": "tsc",
-    "test": "jest --config jest.config.json",
+    "build-test": "tsc --project test",
+    "test": "npm run build-test && jest --config jest.config.json",
     "lint": "eslint --ext .js,.ts --fix",
     "prepare": "npm run-script build",
     "release": "standard-version"
@@ -48,6 +50,9 @@
     "@sentry/node": "^7.5.0",
     "@sentry/tracing": "^7.5.0",
     "@sentry/types": "^7.5.0",
+    "@sentry4/types": "npm:@sentry/types@^4.5.3",
+    "@sentry5/types": "npm:@sentry/types@^5.30.0",
+    "@sentry6/types": "npm:@sentry/types@^6.19.7",
     "@types/body-parser": "^1.19.2",
     "@types/express": "^4.17.14",
     "@types/jest": "^27.0.0",
@@ -65,6 +70,7 @@
     "nock": "^10.0.6",
     "node-fetch": "^2.6.7",
     "prettier": "^1.19.1",
+    "rimraf": "^3.0.2",
     "standard-version": "^9.3.1",
     "ts-jest": "^27.0.0",
     "typescript": "^4.8.4",

--- a/test/backwardsCompatibleTransportTypes.ts
+++ b/test/backwardsCompatibleTransportTypes.ts
@@ -1,0 +1,55 @@
+// This file is deliberately not named .test.ts as we don't want Jest to run it, we just want tsc to type check it
+
+import * as V7SentryTypes from '@sentry/types'
+import * as V4SentryTypes from '@sentry4/types'
+import * as V5SentryTypes from '@sentry5/types'
+import * as V6SentryTypes from '@sentry6/types'
+import sentryTestkit from '../src'
+
+const { sentryTransport } = sentryTestkit()
+const DUMMY_DSN = 'https://acacaeaccacacacabcaacdacdacadaca@sentry.io/000001'
+
+test('v7 transport', () => {
+  const transportCreator: Required<
+    V7SentryTypes.Options
+  >['transport'] = sentryTransport
+  let transport = transportCreator({
+    url: DUMMY_DSN,
+    recordDroppedEvent: jest.fn(),
+  })
+  transport.send([{ sent_at: 'sometime' }, []])
+  transport.flush(1)
+})
+
+test('v6 transport', () => {
+  const TransportCreator: Required<
+    V6SentryTypes.Options
+  >['transport'] = sentryTransport
+  let transport = new TransportCreator({ dsn: DUMMY_DSN })
+  transport.sendEvent({})
+  transport.sendSession!({ aggregates: [] })
+  transport.recordLostEvent!('event_processor', 'event')
+  transport.close(1)
+})
+
+test('v5 transport', () => {
+  const TransportCreator: Required<
+    V5SentryTypes.Options
+  >['transport'] = sentryTransport
+  let transport = new TransportCreator({ dsn: DUMMY_DSN })
+  transport.sendEvent({})
+  transport.sendSession!({
+    update: jest.fn(),
+    close: jest.fn(),
+    toJSON: jest.fn(),
+  })
+  transport.close(1)
+})
+
+test('v4 transport', () => {
+  const TransportCreator: V4SentryTypes.TransportClass<V4SentryTypes.Transport> = sentryTransport
+  let transport = new TransportCreator({ dsn: DUMMY_DSN })
+  transport.sendEvent('body')
+  transport.captureEvent!({})
+  transport.close(1)
+})

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+  },
+  "include": ["**/*"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,4 @@
     "forceConsistentCasingInFileNames": true
   },
   "include": ["src/**/*"]
-  // "files": ["./test/**/*.ts"]
 }


### PR DESCRIPTION
I've started looking at #142.

Question; how far back do we want backward compatibility in the types?

Currently, looking at the code comments in `createSentryTransport` it looks like we're trying to support all the way back to v4? Or are we only interested in v6 and v7 nowadays? Asking because more backwards compatibility = more work. :)

Progress so far;

I've added some type tests for the transport, these will currently pass due to the `any` return type on `createSentryTransport`. If you were to remove the `any` return then you'd see the new test file passing for v7 but failing for 6, 5 and 4.

I've had to add these tests as a separate `build-test` script with it's own TypeScript project because the tests can't type-check without a build producing `dist/**` (due to the CJS and ESM tests using `dist`) and doing a build runs the tests; a catch-22.