### PR TITLE
docs: fix typo in documentation

### DIFF
--- a/LEGACY_API.md
+++ b/LEGACY_API.md
@@ -57,7 +57,7 @@ Get all existing reports.
 <a name="reset"></a>
 
 ### reset() : <code>Array</code>
-Reset the teskit state and clear all existing reports.
+Reset the testkit state and clear all existing reports.
 
 **Returns**: <code>Array</code> - empty array.
 <a name="extractException"></a>

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 </p>
 <p align="center">
 <a href="https://zivl.github.io/sentry-testkit/">
-    <img alt="sentry-teskit" src="./docs/logo/Sentry_github.svg" height="132">
+    <img alt="sentry-testkit" src="./docs/logo/Sentry_github.svg" height="132">
     </a>
 </p>
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,12 +1,12 @@
 <div style="text-align: center;">
-    <img alt="sentry-teskit" src="./logo/Sentry_github.svg" style="height: 140px;">
+    <img alt="sentry-testkit" src="./logo/Sentry_github.svg" style="height: 140px;">
 </div>
 <div style="text-align: center;">
-    <img alt="sentry-teskit-npm" src="https://img.shields.io/npm/v/sentry-testkit.svg">
-    <img alt="sentry-teskit-downloads" src="https://img.shields.io/npm/dm/sentry-testkit.svg">
-    <img alt="sentry-teskit-tests" src="https://github.com/zivl/sentry-testkit/workflows/Test/badge.svg">
-    <img alt="sentry-teskit-v6" src="https://img.shields.io/badge/Compatible%20with%20Sentry-v6-blue">
-    <img alt="sentry-teskit-v7" src="https://img.shields.io/badge/Compatible%20with%20Sentry-v7-blue">
+    <img alt="sentry-testkit-npm" src="https://img.shields.io/npm/v/sentry-testkit.svg">
+    <img alt="sentry-testkit-downloads" src="https://img.shields.io/npm/dm/sentry-testkit.svg">
+    <img alt="sentry-testkit-tests" src="https://github.com/zivl/sentry-testkit/workflows/Test/badge.svg">
+    <img alt="sentry-testkit-v6" src="https://img.shields.io/badge/Compatible%20with%20Sentry-v6-blue">
+    <img alt="sentry-testkit-v7" src="https://img.shields.io/badge/Compatible%20with%20Sentry-v7-blue">
 </div>
 
 

--- a/docs/raven/LEGACY_API.md
+++ b/docs/raven/LEGACY_API.md
@@ -49,7 +49,7 @@ Get all existing reports.
 <a name="reset"></a>
 
 ### reset() : <code>Array</code>
-Reset the teskit state and clear all existing reports.
+Reset the testkit state and clear all existing reports.
 
 **Returns**: <code>Array</code> - empty array.
 <a name="extractException"></a>

--- a/website/docs/raven-testkit-legacy.md
+++ b/website/docs/raven-testkit-legacy.md
@@ -57,7 +57,7 @@ Get all existing reports.
 <a name="reset"></a>
 
 ### reset() : <code>Array</code>
-Reset the teskit state and clear all existing reports.
+Reset the testkit state and clear all existing reports.
 
 **Returns**: <code>Array</code> - empty array.
 <a name="extractException"></a>

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -58,9 +58,9 @@ const config = {
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
       navbar: {
-        title: 'sentry-teskit',
+        title: 'sentry-testkit',
         logo: {
-          alt: 'sentry-teskit',
+          alt: 'sentry-testkit',
           src: 'img/logo/logo_only.png',
         },
         items: [

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -15,7 +15,7 @@ function HomepageHeader() {
     <header className={clsx('hero', styles.heroBanner)}>
       <div className="container">
         <img
-          alt="sentry-teskit"
+          alt="sentry-testkit"
           src="img/logo/Sentry_github.svg"
           style={{ height: '140px' }}
         />
@@ -48,23 +48,23 @@ export default function Home(): JSX.Element {
           }}
         >
           <img
-            alt="sentry-teskit-npm"
+            alt="sentry-testkit-npm"
             src="https://img.shields.io/npm/v/sentry-testkit.svg"
           />
           <img
-            alt="sentry-teskit-downloads"
+            alt="sentry-testkit-downloads"
             src="https://img.shields.io/npm/dm/sentry-testkit.svg"
           />
           <img
-            alt="sentry-teskit-tests"
+            alt="sentry-testkit-tests"
             src="https://github.com/zivl/sentry-testkit/workflows/Test/badge.svg"
           />
           <img
-            alt="sentry-teskit-v6"
+            alt="sentry-testkit-v6"
             src="https://img.shields.io/badge/Compatible%20with%20Sentry-v6-blue"
           />
           <img
-            alt="sentry-teskit-v7"
+            alt="sentry-testkit-v7"
             src="https://img.shields.io/badge/Compatible%20with%20Sentry-v7-blue"
           />
         </div>


### PR DESCRIPTION
"teskit" -> "testkit"

This is most visible on the project website

![Screenshot 2023-10-12 at 22 03 42](https://github.com/zivl/sentry-testkit/assets/10211603/b9a56bed-3926-4dd1-b420-169208c32c88)
