### PR TITLE
fix: wrong stacktrace type

### DIFF
--- a/__tests__/commonTests.ts
+++ b/__tests__/commonTests.ts
@@ -77,12 +77,15 @@ export function createCommonTests({
     await waitForExpect(() => expect(testkit.reports()).toHaveLength(1))
   })
 
-  test('should have an error object with the captured exception', async function() {
+  test('should have an error object with the captured exception and stacktrace', async function() {
     Sentry.captureException(new Error('sentry test kit is awesome!'))
     await waitForExpect(() => expect(testkit.reports()).toHaveLength(1))
     expect(testkit.reports()[0]!.error).toMatchObject({
       name: 'Error',
       message: 'sentry test kit is awesome!',
+      stacktrace: {
+        frames: expect.any(Array),
+      },
     })
   })
 

--- a/browser.d.ts
+++ b/browser.d.ts
@@ -3,7 +3,7 @@ import {
   Breadcrumb,
   User,
   SeverityLevel,
-  StackFrame,
+  Stacktrace,
   Transport,
 } from '@sentry/types'
 
@@ -22,7 +22,7 @@ declare namespace sentryTestkit {
   interface ReportError {
     name: string
     message: string
-    stacktrace: StackFrame[]
+    stacktrace: Stacktrace
   }
 
   interface Report {

--- a/docs/api/reportError.md
+++ b/docs/api/reportError.md
@@ -6,5 +6,5 @@ The error name
 #### `message` [string]
 The error message
 
-#### `stacktrace` [[StackFrame[]](https://github.com/getsentry/sentry-javascript/blob/master/packages/types/src/stackframe.ts)]
+#### `stacktrace` [[Stacktrace[]](https://github.com/getsentry/sentry-javascript/blob/master/packages/types/src/stacktrace.ts)]
 The error stacktrace as individual frames

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ import {
   Breadcrumb,
   User,
   SeverityLevel,
-  StackFrame,
+  Stacktrace,
   Transport,
 } from '@sentry/types'
 
@@ -22,7 +22,7 @@ declare namespace sentryTestkit {
   interface ReportError {
     name: string
     message: string
-    stacktrace: StackFrame[]
+    stacktrace: Stacktrace
   }
 
   interface Report {

--- a/website/docs/api/types.md
+++ b/website/docs/api/types.md
@@ -13,10 +13,10 @@ Represents a report error object. The object has the following keys:
     //The error message
     message: string
     // The error stacktrace as individual frames
-    stacktrace: StackFrame[]
+    stacktrace: Stacktrace
   }
 ```
-**See:** [StackFrame](https://github.com/getsentry/sentry-javascript/blob/master/packages/types/src/stackframe.ts)
+**See:** [Stacktrace](https://github.com/getsentry/sentry-javascript/blob/master/packages/types/src/stacktrace.ts)
 
 ### `Report`
 


### PR DESCRIPTION
As shown by updated test, the `stacktrace` property is not an array but an object with a `frames` property of type array.

I suppose it might have changed at some point in SDK but I'm not sure when. I think there is no need to make a major release since it was already wrong.