### PR TITLE
removeListener -> off

### DIFF
--- a/browser.d.ts
+++ b/browser.d.ts
@@ -16,7 +16,7 @@ declare function sentryTestkit<
 declare namespace sentryTestkit {
   interface Page {
     on(event: string, handler: (...args: any[]) => any): void
-    removeListener(event: string, handler: (...args: any[]) => any): void
+    off(event: string, handler: (...args: any[]) => any): void
   }
 
   interface ReportError {

--- a/src/testkit.ts
+++ b/src/testkit.ts
@@ -36,7 +36,7 @@ export function createTestkit(): Testkit {
       },
 
       stopListening: (page: any) => {
-        page.removeListener('request', puppeteerHandler)
+        page.off('request', puppeteerHandler)
       },
     },
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,7 +16,7 @@ declare function sentryTestkit<
 declare namespace sentryTestkit {
   interface Page {
     on(event: string, handler: (...args: any[]) => any): void
-    removeListener(event: string, handler: (...args: any[]) => any): void
+    off(event: string, handler: (...args: any[]) => any): void
   }
 
   interface ReportError {


### PR DESCRIPTION
Puppeteer deprecated the `removeListener` some time ago in favor of `off` and in latest version they removed `removeListener` entirely