### PR TITLE
fix: handle event type in createTestkit to push reports correctly to address Puppeteer events

### DIFF
--- a/src/testkit.ts
+++ b/src/testkit.ts
@@ -24,6 +24,8 @@ export function createTestkit(): Testkit {
       const { type, payload } = parseEnvelopeRequest(request.postData())
       if (type === 'transaction') {
         transactions.push(transformTransaction(payload))
+      } else if (type === 'event') {
+        reports.push(transformReport(payload))
       }
     }
   }


### PR DESCRIPTION
fixes #193